### PR TITLE
chore: add default for layout prop

### DIFF
--- a/packages/qwik-image/src/lib/image.tsx
+++ b/packages/qwik-image/src/lib/image.tsx
@@ -67,7 +67,7 @@ export const getStyles = ({
   height,
   aspectRatio,
   objectFit = 'cover',
-  layout,
+  layout = 'fixed',
 }: Pick<
   ImageProps,
   'placeholder' | 'width' | 'height' | 'aspectRatio' | 'objectFit' | 'layout'


### PR DESCRIPTION
This PR fixes a bug where the `getStyles` function could return `undefined` if the `layout` prop was not provided at runtime, even though it's marked as required in the TypeScript interface.

**Changes:**
- Added default value `'fixed'` for the `layout` parameter in the `getStyles` function destructuring
- This ensures the switch statement always has a valid value to match against
- Consistent with how `objectFit` already has a default value of `'cover'`

**Impact:**
- Prevents potential runtime errors when the component is used without explicitly providing the `layout` prop
- Maintains backward compatibility by using `'fixed'` as the sensible default

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.