### PR TITLE
feat: add Picture component for art-directed responsive images

### DIFF
--- a/.changeset/bright-pictures-direct.md
+++ b/.changeset/bright-pictures-direct.md
@@ -1,0 +1,5 @@
+---
+'qwik-image': minor
+---
+
+Add a `Picture` component for art-directed responsive images.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,52 @@ useImageProvider({
 />
 ```
 
+### Picture component (art direction)
+
+Use `Picture` when you need **different image files per viewport** (e.g. a
+full-width desktop banner and a smaller mobile banner from separate CMS fields).
+It renders a native `<picture>` element, so the browser downloads **only** the
+source whose `media` query matches — unlike two CSS-hidden `<Image>` tags, which
+are both fetched when `loading="eager"`/`fetchpriority="high"` are set (hurting
+LCP).
+
+```tsx
+import { Picture } from 'qwik-image';
+
+export default component$((props) => {
+  return (
+    <Picture
+      layout="fullWidth"
+      alt="Banner"
+      loading="eager"
+      fetchpriority="high"
+      src={props.image}                 // fallback / default (desktop)
+      sources={[
+        { src: props.imageMobile, media: '(max-width: 767px)' },
+        { src: props.image,       media: '(min-width: 768px)' },
+      ]}
+    />
+  );
+});
+```
+
+The visual difference between breakpoints comes from serving **different `src`
+files** — the desktop and mobile images your CMS already provides. Exactly one of
+them is downloaded, and `loading`/`fetchpriority` (set on the fallback `<img>`)
+apply to whichever source the browser selects, so the LCP request is single and
+correctly prioritized.
+
+`Picture` accepts every `Image` prop (`layout`, `objectFit`, `alt`, `loading`,
+`fetchpriority`, `class`, `placeholder`, …) and forwards them to the fallback
+`<img>`. Each entry in `sources` is:
+
+| field | required | description |
+| --- | --- | --- |
+| `src` | yes | Image URL for this source (run through your `imageTransformer$`). |
+| `media` | yes | Media query, e.g. `(min-width: 768px)`. |
+| `type` | no | MIME type, e.g. `image/webp`. |
+| `width` / `height` / `aspectRatio` | no | Per-source overrides for that source's generated `srcset`, following the same rules as `Image` (e.g. `aspectRatio` affects the generated heights only when `height` is also set). Fall back to the `Picture`-level values. |
+
 ## loading values:
 
 Here is the loading values and behaviors https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/loading

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "nx": "nx",
     "build": "nx run qwik-image:build",
     "build.qwik-ci": "nx run qwik-image:build --skip-nx-cache",
-    "test": "echo 'test'"
+    "test": "nx run qwik-image:test"
   },
   "private": false,
   "type": "module",

--- a/packages/qwik-image/project.json
+++ b/packages/qwik-image/project.json
@@ -20,11 +20,11 @@
       }
     },
     "test": {
-      "executor": "@nrwl/vite:test",
-      "outputs": ["../coverage/packages/qwik-image"],
+      "executor": "nx:run-commands",
+      "outputs": [],
       "options": {
-        "passWithNoTests": true,
-        "reportsDirectory": "../../coverage/packages/qwik-image"
+        "cwd": "packages/qwik-image",
+        "command": "vitest run --config vite.config.ts --passWithNoTests"
       }
     },
     "lint": {

--- a/packages/qwik-image/src/index.ts
+++ b/packages/qwik-image/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/image';
+export * from './lib/picture';

--- a/packages/qwik-image/src/lib/picture.spec.tsx
+++ b/packages/qwik-image/src/lib/picture.spec.tsx
@@ -1,0 +1,143 @@
+import { $, Slot, component$ } from '@builder.io/qwik';
+import { createDOM } from '@builder.io/qwik/testing';
+import { describe, expect, it } from 'vitest';
+import { useImageProvider, type ImageTransformerProps } from './image';
+import { Picture, type PictureSource } from './picture';
+
+// `Image`/`Picture` read `ImageContext` via `useContext`, which throws if no
+// ancestor has called `useImageProvider`/`useContextProvider`. Mirrors the
+// `TransformerProvider` wrapper used in
+// apps/qwik-demo-app/src/components/image.spec.tsx.
+const ImageProviderWrapper = component$(() => {
+  useImageProvider({});
+  return <Slot />;
+});
+
+describe('Picture', () => {
+  it('renders a <picture> wrapping a single fallback <img> when sources is omitted', async () => {
+    const { screen, render } = await createDOM();
+    await render(
+      <ImageProviderWrapper>
+        <Picture layout="fullWidth" alt="Banner" src="https://example.com/desktop.jpg" />
+      </ImageProviderWrapper>
+    );
+
+    const picture = screen.querySelector('picture');
+    expect(picture).not.toBeNull();
+    expect(picture?.querySelectorAll('source').length).toBe(0);
+
+    const img = picture?.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('alt')).toBe('Banner');
+  });
+
+  it('renders one <source> per entry with the correct media and type', async () => {
+    const { screen, render } = await createDOM();
+    await render(
+      <ImageProviderWrapper>
+        <Picture
+          layout="fullWidth"
+          alt="Banner"
+          src="https://example.com/desktop.jpg"
+          sources={[
+            { src: 'https://example.com/mobile.jpg', media: '(max-width: 767px)', type: 'image/webp' },
+            { src: 'https://example.com/desktop.jpg', media: '(min-width: 768px)' },
+          ]}
+        />
+      </ImageProviderWrapper>
+    );
+
+    const sources = screen.querySelectorAll('source');
+    expect(sources.length).toBe(2);
+    expect(sources[0].getAttribute('media')).toBe('(max-width: 767px)');
+    expect(sources[0].getAttribute('type')).toBe('image/webp');
+    expect(sources[1].getAttribute('media')).toBe('(min-width: 768px)');
+  });
+
+  it('puts loading and fetchpriority on the fallback <img>, and it is the last child', async () => {
+    const { screen, render } = await createDOM();
+    await render(
+      <ImageProviderWrapper>
+        <Picture
+          layout="fullWidth"
+          alt="Banner"
+          loading="eager"
+          fetchpriority="high"
+          src="https://example.com/desktop.jpg"
+          sources={[{ src: 'https://example.com/mobile.jpg', media: '(max-width: 767px)' }]}
+        />
+      </ImageProviderWrapper>
+    );
+
+    const picture = screen.querySelector('picture')!;
+    const img = picture.querySelector('img');
+    expect(img?.getAttribute('loading')).toBe('eager');
+    expect(img?.getAttribute('fetchpriority')).toBe('high');
+    expect(picture.lastElementChild?.tagName.toLowerCase()).toBe('img');
+  });
+
+  it('passes each source src through the context imageTransformer$', async () => {
+    const transformer$ = $(({ src, width }: ImageTransformerProps): string => {
+      return `${src}?w=${width}`;
+    });
+
+    const Host = component$((hostProps: { sources: PictureSource[] }) => {
+      useImageProvider({ resolutions: [640], imageTransformer$: transformer$ });
+      return (
+        <Picture
+          layout="fullWidth"
+          alt="Banner"
+          src="https://example.com/desktop.jpg"
+          sources={hostProps.sources}
+        />
+      );
+    });
+
+    const { screen, render } = await createDOM();
+    await render(
+      <Host
+        sources={[
+          { src: 'https://example.com/mobile.jpg', media: '(max-width: 767px)' },
+          { src: 'https://example.com/desktop.jpg', media: '(min-width: 768px)' },
+        ]}
+      />
+    );
+
+    const sources = screen.querySelectorAll('source');
+    expect(sources[0].getAttribute('srcset')).toContain('mobile.jpg?w=640');
+    expect(sources[1].getAttribute('srcset')).toContain('desktop.jpg?w=640');
+  });
+
+  it('uses the per-source width override when building that source srcset', async () => {
+    const transformer$ = $(({ src, width }: ImageTransformerProps): string => {
+      return `${src}?w=${width}`;
+    });
+
+    const Host = component$((hostProps: { sources: PictureSource[] }) => {
+      useImageProvider({ imageTransformer$: transformer$ });
+      return (
+        <Picture
+          layout="constrained"
+          width={800}
+          alt="Banner"
+          src="https://example.com/desktop.jpg"
+          sources={hostProps.sources}
+        />
+      );
+    });
+
+    const { screen, render } = await createDOM();
+    await render(
+      <Host
+        sources={[
+          { src: 'https://example.com/mobile.jpg', media: '(max-width: 767px)', width: 400 },
+        ]}
+      />
+    );
+
+    const srcset = screen.querySelector('source')?.getAttribute('srcset') ?? '';
+    // constrained breakpoints for width=400 include 400 and its 2x (800), not 1600.
+    expect(srcset).toContain('w=400');
+    expect(srcset).not.toContain('w=1600');
+  });
+});

--- a/packages/qwik-image/src/lib/picture.spec.tsx
+++ b/packages/qwik-image/src/lib/picture.spec.tsx
@@ -18,7 +18,11 @@ describe('Picture', () => {
     const { screen, render } = await createDOM();
     await render(
       <ImageProviderWrapper>
-        <Picture layout="fullWidth" alt="Banner" src="https://example.com/desktop.jpg" />
+        <Picture
+          layout="fullWidth"
+          alt="Banner"
+          src="https://example.com/desktop.jpg"
+        />
       </ImageProviderWrapper>
     );
 
@@ -40,8 +44,15 @@ describe('Picture', () => {
           alt="Banner"
           src="https://example.com/desktop.jpg"
           sources={[
-            { src: 'https://example.com/mobile.jpg', media: '(max-width: 767px)', type: 'image/webp' },
-            { src: 'https://example.com/desktop.jpg', media: '(min-width: 768px)' },
+            {
+              src: 'https://example.com/mobile.jpg',
+              media: '(max-width: 767px)',
+              type: 'image/webp',
+            },
+            {
+              src: 'https://example.com/desktop.jpg',
+              media: '(min-width: 768px)',
+            },
           ]}
         />
       </ImageProviderWrapper>
@@ -54,6 +65,36 @@ describe('Picture', () => {
     expect(sources[1].getAttribute('media')).toBe('(min-width: 768px)');
   });
 
+  it('renders same-media sources with different formats', async () => {
+    const { screen, render } = await createDOM();
+    await render(
+      <ImageProviderWrapper>
+        <Picture
+          layout="fullWidth"
+          alt="Banner"
+          src="https://example.com/desktop.jpg"
+          sources={[
+            {
+              src: 'https://example.com/banner.avif',
+              media: '(min-width: 768px)',
+              type: 'image/avif',
+            },
+            {
+              src: 'https://example.com/banner.webp',
+              media: '(min-width: 768px)',
+              type: 'image/webp',
+            },
+          ]}
+        />
+      </ImageProviderWrapper>
+    );
+
+    const sources = screen.querySelectorAll('source');
+    expect(sources.length).toBe(2);
+    expect(sources[0].getAttribute('type')).toBe('image/avif');
+    expect(sources[1].getAttribute('type')).toBe('image/webp');
+  });
+
   it('puts loading and fetchpriority on the fallback <img>, and it is the last child', async () => {
     const { screen, render } = await createDOM();
     await render(
@@ -64,7 +105,12 @@ describe('Picture', () => {
           loading="eager"
           fetchpriority="high"
           src="https://example.com/desktop.jpg"
-          sources={[{ src: 'https://example.com/mobile.jpg', media: '(max-width: 767px)' }]}
+          sources={[
+            {
+              src: 'https://example.com/mobile.jpg',
+              media: '(max-width: 767px)',
+            },
+          ]}
         />
       </ImageProviderWrapper>
     );
@@ -74,6 +120,24 @@ describe('Picture', () => {
     expect(img?.getAttribute('loading')).toBe('eager');
     expect(img?.getAttribute('fetchpriority')).toBe('high');
     expect(picture.lastElementChild?.tagName.toLowerCase()).toBe('img');
+  });
+
+  it('forwards priority to the fallback <img>', async () => {
+    const { screen, render } = await createDOM();
+    await render(
+      <ImageProviderWrapper>
+        <Picture
+          layout="fullWidth"
+          alt="Banner"
+          priority
+          src="https://example.com/desktop.jpg"
+        />
+      </ImageProviderWrapper>
+    );
+
+    const img = screen.querySelector('picture img');
+    expect(img?.getAttribute('loading')).toBe('eager');
+    expect(img?.getAttribute('fetchpriority')).toBe('high');
   });
 
   it('passes each source src through the context imageTransformer$', async () => {
@@ -97,8 +161,14 @@ describe('Picture', () => {
     await render(
       <Host
         sources={[
-          { src: 'https://example.com/mobile.jpg', media: '(max-width: 767px)' },
-          { src: 'https://example.com/desktop.jpg', media: '(min-width: 768px)' },
+          {
+            src: 'https://example.com/mobile.jpg',
+            media: '(max-width: 767px)',
+          },
+          {
+            src: 'https://example.com/desktop.jpg',
+            media: '(min-width: 768px)',
+          },
         ]}
       />
     );
@@ -130,7 +200,11 @@ describe('Picture', () => {
     await render(
       <Host
         sources={[
-          { src: 'https://example.com/mobile.jpg', media: '(max-width: 767px)', width: 400 },
+          {
+            src: 'https://example.com/mobile.jpg',
+            media: '(max-width: 767px)',
+            width: 400,
+          },
         ]}
       />
     );

--- a/packages/qwik-image/src/lib/picture.tsx
+++ b/packages/qwik-image/src/lib/picture.tsx
@@ -1,9 +1,4 @@
-import {
-  component$,
-  useContext,
-  useSignal,
-  useTask$,
-} from '@builder.io/qwik';
+import { component$, useContext, useSignal, useTask$ } from '@builder.io/qwik';
 import {
   getSizes,
   getSrcSet,
@@ -32,6 +27,7 @@ export interface PictureProps extends ImageProps {
 }
 
 type ComputedPictureSource = {
+  key: string;
   media: string;
   type?: string;
   srcset: string;
@@ -70,7 +66,8 @@ export const Picture = component$<PictureProps>((props) => {
         // and `getSizes` interpolates the value directly into the template
         // string, so this cast is behavior-preserving for both.
         const effectiveWidth = (source.width ?? width) as ImageProps['width'];
-        const effectiveHeight = (source.height ?? height) as ImageProps['height'];
+        const effectiveHeight = (source.height ??
+          height) as ImageProps['height'];
         const effectiveAspectRatio = source.aspectRatio ?? aspectRatio;
 
         const srcset = await getSrcSet({
@@ -84,6 +81,7 @@ export const Picture = component$<PictureProps>((props) => {
         });
 
         return {
+          key: `${source.media}:${source.type ?? ''}:${source.src}`,
           media: source.media,
           type: source.type,
           srcset,
@@ -97,7 +95,7 @@ export const Picture = component$<PictureProps>((props) => {
     <picture>
       {computedSourcesSig.value.map((source) => (
         <source
-          key={source.media}
+          key={source.key}
           media={source.media}
           type={source.type}
           srcset={source.srcset}

--- a/packages/qwik-image/src/lib/picture.tsx
+++ b/packages/qwik-image/src/lib/picture.tsx
@@ -1,0 +1,110 @@
+import {
+  component$,
+  useContext,
+  useSignal,
+  useTask$,
+} from '@builder.io/qwik';
+import {
+  getSizes,
+  getSrcSet,
+  Image,
+  ImageContext,
+  type ImageProps,
+} from './image';
+
+/**
+ * @alpha
+ */
+export type PictureSource = {
+  src: string;
+  media: string;
+  type?: string;
+  width?: number | string;
+  height?: number | string;
+  aspectRatio?: number;
+};
+
+/**
+ * @alpha
+ */
+export interface PictureProps extends ImageProps {
+  sources?: PictureSource[];
+}
+
+type ComputedPictureSource = {
+  media: string;
+  type?: string;
+  srcset: string;
+  sizes?: string;
+};
+
+/**
+ * @alpha
+ */
+export const Picture = component$<PictureProps>((props) => {
+  const computedSourcesSig = useSignal<ComputedPictureSource[]>([]);
+  const state = useContext(ImageContext);
+  const { sources, resolutions, imageTransformer$, ...imageAttributes } = {
+    ...state,
+    ...props,
+  };
+  const imageAttributesWithoutChildren = {
+    ...imageAttributes,
+    children: undefined,
+  };
+
+  useTask$(async ({ track }) => {
+    const sources = track(() => props.sources) ?? [];
+    const width = track(() => props.width);
+    const height = track(() => props.height);
+    const aspectRatio = track(() => props.aspectRatio);
+    const layout = track(() => props.layout);
+
+    computedSourcesSig.value = await Promise.all(
+      sources.map(async (source) => {
+        // `PictureSource.width`/`height` accept any `string` (per-source
+        // override ergonomics), but `getSrcSet`/`getSizes` type their
+        // `width`/`height` params as `ImageProps['width']`/`['height']`
+        // (Qwik's `Numberish` JSX attribute type, i.e. `number |
+        // \`${number}\``). `getSrcSet` parses numeric strings via `parseInt`
+        // and `getSizes` interpolates the value directly into the template
+        // string, so this cast is behavior-preserving for both.
+        const effectiveWidth = (source.width ?? width) as ImageProps['width'];
+        const effectiveHeight = (source.height ?? height) as ImageProps['height'];
+        const effectiveAspectRatio = source.aspectRatio ?? aspectRatio;
+
+        const srcset = await getSrcSet({
+          src: source.src,
+          width: effectiveWidth,
+          height: effectiveHeight,
+          aspectRatio: effectiveAspectRatio,
+          layout,
+          resolutions,
+          imageTransformer$,
+        });
+
+        return {
+          media: source.media,
+          type: source.type,
+          srcset,
+          sizes: getSizes({ width: effectiveWidth, layout }),
+        };
+      })
+    );
+  });
+
+  return (
+    <picture>
+      {computedSourcesSig.value.map((source) => (
+        <source
+          key={source.media}
+          media={source.media}
+          type={source.type}
+          srcset={source.srcset}
+          sizes={source.sizes}
+        />
+      ))}
+      <Image {...imageAttributesWithoutChildren} />
+    </picture>
+  );
+});

--- a/packages/qwik-image/vite.config.ts
+++ b/packages/qwik-image/vite.config.ts
@@ -23,9 +23,7 @@ export default defineConfig({
       skipDiagnostics: true,
     }),
     viteStaticCopy({
-      targets: [
-        { src: '../../README.md', dest: './' },
-      ],
+      targets: [{ src: '../../README.md', dest: './' }],
     }),
   ],
   server: {
@@ -61,6 +59,14 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    alias: {
+      '@builder.io/qwik/build': fileURLToPath(
+        new URL(
+          '../../node_modules/@builder.io/qwik/dist/build/index.mjs',
+          import.meta.url
+        )
+      ),
+    },
     coverage: {
       reportsDirectory: '../../coverage/packages/qwik-image',
     },


### PR DESCRIPTION
## What

Issue: https://github.com/QwikDev/qwik-image/issues/17

Adds a `Picture` component for **art-directed responsive images** — serving different image files per viewport (e.g. a full-width desktop banner and a smaller mobile banner) via a native `<picture>` element.

```tsx
import { Picture } from 'qwik-image';

<Picture
  layout="fullWidth"
  alt="Banner"
  loading="eager"
  fetchpriority="high"
  src={props.image}                 // fallback / default (desktop)
  sources={[
    { src: props.imageMobile, media: '(max-width: 767px)' },
    { src: props.image,       media: '(min-width: 768px)' },
  ]}
/>
```

## Why

A common pattern for different mobile/desktop banners is two `<Image>` tags toggled with CSS (`hidden md:block`). But `loading="eager"` and `fetchpriority="high"` are honored by the browser **even for `display:none` elements**, so *both* images get fetched on the critical path — an LCP regression Lighthouse flags.

`<picture>` with `<source media>` fixes this at the platform level: the browser evaluates the media queries and downloads **only** the matching source. `loading`/`fetchpriority` on the fallback `<img>` apply to whichever source is selected, so exactly one request is made and correctly prioritized.

## How

- Reuses the existing `Image` component as the required fallback `<img>` child, and the existing `getSrcSet`/`getSizes` helpers for each source's responsive `srcset`.
- Per-source `width`/`height`/`aspectRatio` overrides (fall back to `Picture`-level values) for tuning each source's generated `srcset`.
- `resolutions`/`imageTransformer$` come from the existing `ImageContext`, so the global `useImageProvider` config applies with no extra wiring.
- **`Image`'s public API and behavior are unchanged** — `Picture` is a new, additive export.

## Tests

Adds `picture.spec.tsx` — 5 tests via `@builder.io/qwik/testing`'s `createDOM` — covering: fallback-only render, one `<source>` per entry with correct `media`/`type`, `loading`/`fetchpriority` on the `<img>` (verified as the last child), each source's `src` flowing through `imageTransformer$`, and per-source `width` override affecting that source's `srcset`.

> Note: this also repoints the `qwik-image:test` nx target to run `vitest` directly, because the `@nrwl/vite:test` executor (Nx 19.7.4) is incompatible with the repo's pinned `vitest@0.30.1`/`vite@4.3.1`. Happy to split that into a separate change if preferred. CI (`.github/workflows/test.yml`) currently installs deps but doesn't run the test target — worth adding a `test` step in a follow-up so these tests execute on PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)